### PR TITLE
Possible race condition with append()

### DIFF
--- a/lib/client/js/ui/renderers.jquery.js
+++ b/lib/client/js/ui/renderers.jquery.js
@@ -25,14 +25,14 @@ Node.prototype.render = function() {
   
   // Render LogFiles
   _(n.log_files).each(function(log_file, llabel) {
-    log_file.render();
+    log_file.render(n._dom);
   });
 }
 Node.prototype.destroy = function() {
   this._dom.remove();
 }
 
-LogFile.prototype.render = function() {
+LogFile.prototype.render = function(groupDom) {
   var log_file = this;
   var dom = $("#log_file_template").clone()
     .find(".label").html(this.label).end()
@@ -88,7 +88,10 @@ LogFile.prototype.render = function() {
     // Add to log file list in alphabetical order
     var group = this.node._dom.find(".group2");
     if (!group.children(":gt(0)").length || log_file.label > group.children(":last").data('label')) {
-      dom.appendTo("#node_" + this.node.label + " .group2");
+      if(groupDom)
+        dom.appendTo(groupDom);
+      else
+        dom.appendTo("#node_" + this.node.label + " .group2");
     } else if (log_file.label < group.children(":eq(1)").data('label')) {
       group.children(":first").after(dom);
     } else {


### PR DESCRIPTION
It seems that some kind of race condition can happen. The append of the group isn't propageted to the DOM-tree when "dom.appendTo("#node_" + this.node.label + " .group2");" is called. So I added the group-dom as additional argument to the log-giles render-function.

This is just a quick hack and not fully tested, but it fixed the problem for me.
