### PR TITLE
Fixed hardcoded /usr/local/lib/node_modules to be based on 'which node'

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -11,7 +11,7 @@ if ! which node >/dev/null; then
   exit 1;
 fi
 
-NODE_PATH=`which node`/../../lib/node_modules/
+NODE_PATH=`dirname \`which node\``/../lib/node_modules/
 echo "Checking dependencies in $NODE_PATH";
 
 # Check node.js dependencies


### PR DESCRIPTION
I was installing log.io in a non standard path and noticed the hard-coded ./configure path.  I updated it to be based on where node is installed.
