### PR TITLE
Fix and improve server/harvester logging

### DIFF
--- a/bin/log.io-harvester
+++ b/bin/log.io-harvester
@@ -1,13 +1,6 @@
 #!/usr/bin/env node
-winston = require('winston');
-logging = new winston.Logger({
-  transports: [ new winston.transports.Console({
-    level: 'error'
-  })]
-});
 homeDir = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
 conf = require(homeDir + '/.log.io/harvester.conf').config;
-conf.logging = logging;
 harvester = require('log.io');
 harvester = new harvester.LogHarvester(conf);
 harvester.run();

--- a/bin/log.io-server
+++ b/bin/log.io-server
@@ -1,15 +1,7 @@
 #!/usr/bin/env node
-winston = require('winston');
-logging = new winston.Logger({
-  transports: [ new winston.transports.Console({
-    level: 'error'
-  })]
-});
 homeDir = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
 webConf = require(homeDir + '/.log.io/web_server.conf').config;
-webConf.logging = logging;
 logConf = require(homeDir + '/.log.io/log_server.conf').config;
-logConf.logging = logging;
 server = require('log.io');
 logServer = new server.LogServer(logConf);
 webServer = new server.WebServer(logServer, webConf);

--- a/conf/log_server.conf
+++ b/conf/log_server.conf
@@ -1,4 +1,5 @@
 exports.config = {
   host: '0.0.0.0',
-  port: 28777
+  port: 28777,
+  log_level: 'info'
 }

--- a/conf/web_server.conf
+++ b/conf/web_server.conf
@@ -1,6 +1,7 @@
 exports.config = {
   host: '0.0.0.0',
   port: 28778,
+  log_level: 'info',
 
   /* 
   // Enable HTTP Basic Authentication

--- a/src/harvester.coffee
+++ b/src/harvester.coffee
@@ -30,8 +30,6 @@ net = require 'net'
 events = require 'events'
 util = require './util'
 
-class _LogObject
-
 ###
 LogStream is a group of local files paths.  It watches each file for
 changes, extracts new log messages, and emits 'new_log' events.

--- a/src/harvester.coffee
+++ b/src/harvester.coffee
@@ -28,7 +28,9 @@ harvester.run()
 fs = require 'fs'
 net = require 'net'
 events = require 'events'
-winston = require 'winston'
+util = require './util'
+
+class _LogObject
 
 ###
 LogStream is a group of local files paths.  It watches each file for
@@ -84,7 +86,7 @@ class LogHarvester
   constructor: (config) ->
     {@nodeName, @server} = config
     @delim = config.delimiter ? '\r\n'
-    @_log = config.logging ? winston
+    @_log = config.logging ? util.logger(config.log_level ? 'info')
     @logStreams = (new LogStream s, paths, @_log for s, paths of config.logStreams)
 
   run: ->

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -1,0 +1,18 @@
+### Log.io Util
+
+
+###
+
+winston = require 'winston'
+
+exports.logger = (level = "info") ->
+  new winston.Logger
+    levels:
+      debug: 0
+      info: 1
+      warn: 2
+      error: 3
+    transports: [new winston.transports.Console
+      level: level,
+      colorize: true,
+      timestamp: true]

--- a/test/functional.coffee
+++ b/test/functional.coffee
@@ -17,8 +17,9 @@ should = chai.should()
 {LogHarvester} = require '../../lib/harvester.js'
 {LogServer, WebServer} = require '../../lib/server.js'
 {WebClient} = require '../../lib/client.js'
-logging = new winston.Logger
-  transports: [ new winston.transports.Console level: 'error']
+util = require '../../lib/util.js'
+
+logging = util.logger 'warn'
 
 # Configuration
 


### PR DESCRIPTION
First, thanks for the great app.  Started playing with Log.io yesterday and once I got things running it was excellent.  Works very well with our existing Logstash setup to provide a realtime view of events.

It did take me some time to get it going though, which wasn't helped by the logging of Log.io itself being more or less broken (for me at least).  I've tried to fix a few things:
- Extracted logger to a util file to reduce repetition between server/harvester
- Allowed logging to be overridden by the config as it seems was originally intended (this was broken by the scripts in /bin)
- Fixed winston's broken default log levels
- Added 'log_level' option to the config for cases where don't want to replace the whole logger
- Set socket.io to use the same logger as the web server

I'm decent at JS but still learning, and entirely new to Coffee, so if I've made any major mistakes let me know.  Have a few other patches I'll submit later for bugs I've hit since getting the logging visible.
