### PR TITLE
Adding existing nodes to existing streams

### DIFF
--- a/src/server.coffee
+++ b/src/server.coffee
@@ -139,6 +139,8 @@ class LogServer extends events.EventEmitter
     @_log.debug "Log message: (#{sname}, #{nname}, #{logLevel}) #{message}"
     node = @logNodes[nname] or @_addNode nname, sname
     stream = @logStreams[sname] or @_addStream sname, nname
+    if stream.pairs and not stream.pairs[nname]
+      @_addStream sname, nname
     @emit 'new_log', stream, node, logLevel, message
 
   __add: (name, pnames, _collection, _objClass, objName) ->


### PR DESCRIPTION
Ran into a case where an already existing node would not be added to an additional stream when using only +log messages coming over the TCP socket.  Added a test case for the TCP socket in general and this specific case, as well as the fix of ensuring the node and stream are paired.
