### PR TITLE
Fix for automatic scrolling in Chrome

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -563,7 +563,7 @@ class LogScreenView extends backbone.View
 
   _recordScroll: (e) =>
     msgs = @$el.find '.messages'
-    @forceScroll = (msgs.height() + msgs[0].scrollTop) is msgs[0].scrollHeight
+    @forceScroll = (parseInt(msgs.height(),10) + msgs[0].scrollTop) is msgs[0].scrollHeight
 
   _renderNewLog: (lmessage) =>
     _msg = lmessage.get 'message'


### PR DESCRIPTION
jQuery height() returns floats in Chrome 28.0.1500.95 on Ubuntu 12.04. This breaks the automatic scrolling.
