### PR TITLE
Added glob pattern support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "socket.io-client": "~0.9.11",
     "express": "~3.0.1",
     "winston": "~0.6.2",
-    "coffee-script": "~1.4.0"
+    "coffee-script": "~1.4.0",
+    "glob": "~5.0.14"
   },
   "devDependencies": {
     "browserify": "~1.16.6",

--- a/src/harvester.coffee
+++ b/src/harvester.coffee
@@ -29,6 +29,7 @@ fs = require 'fs'
 net = require 'net'
 events = require 'events'
 winston = require 'winston'
+glob = require 'glob'
 
 ###
 LogStream is a group of local files paths.  It watches each file for
@@ -40,7 +41,14 @@ class LogStream extends events.EventEmitter
 
   watch: ->
     @_log.info "Starting log stream: '#{@name}'"
-    @_watchFile path for path in @paths
+    unglobbed_files = []
+    for path in @paths
+      do(path) ->
+        if glob.hasMagic(path)
+          unglobbed_files.push file for file in glob.sync(path)
+        else
+          unglobbed_files.push path
+    @_watchFile file for file in unglobbed_files      
     @
 
   _watchFile: (path) ->


### PR DESCRIPTION
The harvester will use all files that match a glob pattern, e.g. /*.log.
