### PR TITLE
Fix #139, Improved performance by removing memory leak caused by high…

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -23,7 +23,8 @@ _ = require 'underscore'
 templates = require './templates'
 
 # Cap LogMessages collection size
-MESSAGE_CAP = 5000
+# Keeping message cap as small as possible to improve perfomance and eliminate memory leak
+MESSAGE_CAP = 1
 
 ###
 ColorManager acts as a circular queue for color values.


### PR DESCRIPTION
Something that I noticed works quite well and improves performance is changing the client message_cap to a lower number. For example I changed it to 1 and it really boosted performance, the difference was night and day.
Even at 200,000 messages there is no lag at all when the message_cap variable is reduced to 1!
As opposed to before with the previous cap at 5000 the page started crawling at ~ 20,000 messages and browser freezing at ~ 70,000 messages.

I analyzed the code and I don't see any use for having a larger message_cap, at least not in the current tag v0.3.4. My assumption is this is left over from a legacy feature. Otherwise, keeping the LogMessages backbone collection as small as possible tremendously improved the usability.

client.coffee line 26 v0.3.4
MESSAGE_CAP = 1
