### PR TITLE
Persist screen binding state using URL hash

### DIFF
--- a/ui/src/components/app/index.tsx
+++ b/ui/src/components/app/index.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useReducer } from 'react'
+import initializeState from './initialize'
 import { DispatchContext, StateContext } from '../../contexts'
 import InputManager from '../inputs'
 import reducer from '../../reducers'
 import { State } from '../../reducers/types'
-import { ScreenActions } from '../../reducers/screens/types'
 import ScreenManager from '../screens'
 import {
   registerNewInput,
@@ -31,8 +31,8 @@ const App: React.FC<AppProps> = ({ initialState, socket }) => {
   useEffect(() => registerPing(socket, dispatch), [dispatch, socket])
   useEffect(() => registerNewMessage(socket, dispatch), [dispatch, socket])
 
-  // Create initial screen
-  useEffect(() => dispatch({ type: ScreenActions.ADD_SCREEN }), [dispatch])
+  // Initialize screens & bindings from URL
+  useEffect(() => initializeState(dispatch, window.location.hash), [dispatch, socket])
 
   return (
     <DispatchContext.Provider value={dispatch}>

--- a/ui/src/components/app/initialize.ts
+++ b/ui/src/components/app/initialize.ts
@@ -1,0 +1,54 @@
+import { Dispatch } from 'react'
+import { UrlBindingStateType } from '../../middleware/url'
+import { BindingActions } from '../../reducers/bindings/types'
+import { InputActions } from '../../reducers/inputs/types'
+import { ScreenActions } from '../../reducers/screens/types'
+import { ActionTypes } from '../../reducers/types'
+
+/**
+ * Initializes screen state & any saved input bindings.
+ * Parses saved state from URL location hash
+ */
+const initializeState = (
+  dispatch: Dispatch<ActionTypes>,
+  locationHash: string
+) => {
+  if (locationHash === '' || locationHash === '#') {
+    dispatch({ type: ScreenActions.ADD_SCREEN })
+    return
+  }
+  // Parse screen state from URL hash
+  let screens: UrlBindingStateType = {}
+  try {
+    screens = JSON.parse(decodeURI(locationHash.slice(1)))
+  } catch (e) {
+    console.warn("Unable to parse previous screen state:", locationHash)
+    dispatch({ type: ScreenActions.ADD_SCREEN })
+    return
+  }
+  // Trigger redux actions to initialize screens, inputs, and bindings
+  Object.keys(screens).forEach((screenId) => {
+    dispatch({
+      type: ScreenActions.ADD_SCREEN,
+      screenId,
+    })
+    screens[screenId].forEach((inputName) => {
+      const [stream, source] = inputName.split('|')
+      dispatch({
+        type: InputActions.ENSURE_INPUT,
+        inputName,
+        stream,
+        source,
+      })
+      dispatch({
+        type: BindingActions.BIND_INPUT_TO_SCREEN,
+        inputName,
+        stream,
+        source,
+        screenId,
+      })
+    })
+  })
+}
+
+export default initializeState

--- a/ui/src/middleware/url.ts
+++ b/ui/src/middleware/url.ts
@@ -1,0 +1,36 @@
+import { BindingActions } from '../reducers/bindings/types'
+import { ScreenActions } from '../reducers/screens/types'
+import { ActionTypes, State } from '../reducers/types'
+
+export type UrlBindingStateType = {
+  [screenId: string]: Array<string>
+}
+
+/**
+ * Update URL hash with binding state
+ */
+const urlMiddleware = (
+  socket: SocketIOClient.Socket,
+  state: State,
+  action: ActionTypes
+): void => {
+  const { bindings } = state
+  switch(action.type) {
+    case BindingActions.BIND_STREAM_TO_SCREEN:
+    case BindingActions.UNBIND_STREAM_FROM_SCREEN:
+    case BindingActions.BIND_SOURCE_TO_SCREEN:
+    case BindingActions.UNBIND_SOURCE_FROM_SCREEN:
+    case BindingActions.BIND_INPUT_TO_SCREEN:
+    case BindingActions.UNBIND_INPUT_FROM_SCREEN:
+    case ScreenActions.REMOVE_SCREEN: {
+      const urlBindingState: UrlBindingStateType = {}
+      Object.keys(bindings.screens).forEach((screenId) => {
+        urlBindingState[screenId] = Object.keys(bindings.screens[screenId].inputs)
+          .filter((inputName) => bindings.screens[screenId].inputs[inputName])
+      })
+      window.location.hash = JSON.stringify(urlBindingState)
+    }
+  }
+}
+
+export default urlMiddleware

--- a/ui/src/reducers/bindings/index.ts
+++ b/ui/src/reducers/bindings/index.ts
@@ -1,7 +1,7 @@
 import produce from 'immer'
 
 import { BindingActions, BindingState, BindingActionTypes } from './types'
-import { InputState } from '../inputs/types'
+import { InputActions, InputState } from '../inputs/types'
 import { ScreenActions } from '../screens/types'
 
 export const initialBindingState: BindingState = {
@@ -209,6 +209,22 @@ export const BindingReducer = produce((
         }
       })
       delete state.screens[screenId]
+      break
+    }
+
+    // Delete associated stream & source screen bindings when a new input arrives
+    case InputActions.ENSURE_INPUT: {
+      const { inputName, stream, source } = action
+      if (state.sources[source] && !inputs.inputs[inputName]) {
+        Object.keys(state.sources[source]).forEach((screenId) => {
+          delete state.sources[source][screenId]
+        })
+      }
+      if (state.streams[stream] && !inputs.inputs[inputName]) {
+        Object.keys(state.streams[stream]).forEach((screenId) => {
+          delete state.streams[stream][screenId]
+        })
+      }
       break
     }
   }

--- a/ui/src/reducers/bindings/types.ts
+++ b/ui/src/reducers/bindings/types.ts
@@ -1,4 +1,5 @@
 import { ScreenActionTypes } from '../screens/types'
+import { EnsureInputAction } from '../inputs/types'
 
 export const BindingActions = {
   BIND_INPUT_TO_SCREEN: 'BIND_INPUT_TO_SCREEN' as 'BIND_INPUT_TO_SCREEN',
@@ -70,3 +71,4 @@ export type BindingActionTypes = BindInputToScreenAction
   | UnbindSourceFromScreenAction
   | UnbindStreamFromScreenAction
   | ScreenActionTypes
+  | EnsureInputAction

--- a/ui/src/reducers/index.ts
+++ b/ui/src/reducers/index.ts
@@ -5,6 +5,7 @@ import MessageReducer, { initialMessageState } from './messages'
 import { InputActionTypes } from './inputs/types'
 import { MessageActionTypes } from './messages/types'
 import socketMiddleware from '../middleware/socket'
+import urlMiddleware from '../middleware/url'
 import ScreenReducer, { initialScreenState } from './screens'
 import { ScreenActionTypes } from './screens/types'
 import { ActionTypes, State } from './types'
@@ -27,6 +28,7 @@ export const Reducer = (state: State, action: ActionTypes): State => {
     socket,
   }
   socketMiddleware(socket, newState, action)
+  urlMiddleware(socket, newState, action)
   return newState
 }
 

--- a/ui/src/reducers/screens/index.ts
+++ b/ui/src/reducers/screens/index.ts
@@ -21,7 +21,7 @@ export const ScreenReducer = produce((
   switch (action.type) {
     // Create a new screen
     case ScreenActions.ADD_SCREEN: {
-      const screenId = generateScreenId()
+      const screenId = action.screenId || generateScreenId()
       screens[screenId] = {
         id: screenId,
         messages: [],

--- a/ui/src/reducers/screens/types.ts
+++ b/ui/src/reducers/screens/types.ts
@@ -14,6 +14,7 @@ export type ScreenState = {
 
 export type AddScreenAction = {
   type: typeof ScreenActions.ADD_SCREEN,
+  screenId?: string,
 }
 
 export type RemoveScreenAction = {


### PR DESCRIPTION
Implements feature requested by #210 

All screen bindings are stored in the URL hash, which gets updated as a user binds & unbinds inputs.  Allows users to share their specific binding session by sending their URL to other users.