### PR TITLE
Gracefully handle file move/remove events

### DIFF
--- a/inputs/file/src/input.ts
+++ b/inputs/file/src/input.ts
@@ -86,6 +86,11 @@ async function startFileWatcher(
       console.error(err)
     }
   })
+  // If a file is removed (or moved), delete its file descriptor & size
+  watcher.on('unlink', (filePath: string) => {
+    delete fileSizes[filePath]
+    delete fds[filePath]
+  })
 }
 
 /**


### PR DESCRIPTION
Addresses a common log rotation scenario where a watched file is moved and a new file of the same name is created.